### PR TITLE
Removes sonar-project.properties file.

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,0 @@
-sonar.projectKey=com.jonfreer.wedding.guest
-sonar.projectName=com.jonfreer.wedding.guest
-sonar.projectVersion=1.0.1
-sonar.sources=.


### PR DESCRIPTION
## Notes

- It appears that the configuration specified in the`sonar-project.properties` file is being overridden by the configuration in the `pom.xml`.