### PR TITLE
Fixes Travis CI badge to point at development, not master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# com.jonfreer.wedding.guest [![Build Status](https://travis-ci.org/freerjm/com.jonfreer.wedding.guest.svg?branch=master)](https://travis-ci.org/freerjm/com.jonfreer.wedding.guest)
+# com.jonfreer.wedding.guest [![Build Status](https://travis-ci.org/freerjm/com.jonfreer.wedding.guest.svg?branch=development)](https://travis-ci.org/freerjm/com.jonfreer.wedding.guest)
 
 A RESTful microservice responsible for all guest and guest reservation functionality.


### PR DESCRIPTION
## Notes

- The markdown for the Travis CI badge was incorrect. This pull request includes all changes necessary to make the Travis CI badge reflect the build status of the `development` branch.